### PR TITLE
Fix "Move out of range" during nozzle clean

### DIFF
--- a/bambufy.cfg
+++ b/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/cs/bambufy.cfg
+++ b/cs/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/de/bambufy.cfg
+++ b/de/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/en/bambufy.cfg
+++ b/en/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/es/bambufy.cfg
+++ b/es/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/fr/bambufy.cfg
+++ b/fr/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/it/bambufy.cfg
+++ b/it/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/ja/bambufy.cfg
+++ b/ja/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/ko/bambufy.cfg
+++ b/ko/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/pt/bambufy.cfg
+++ b/pt/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/ru/bambufy.cfg
+++ b/ru/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0

--- a/zh/bambufy.cfg
+++ b/zh/bambufy.cfg
@@ -1820,7 +1820,7 @@ gcode:
     M106 S{255/100*80}
     G1 Z5
     G1 X70 F7800
-    G1 Z0
+    G1 Z5
     TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={extruder_temp-ifs.probing_temp_diff|int+2}
     G1 Z5
     M106 S0


### PR DESCRIPTION
Proposed fix for https://github.com/function3d/bambufy/issues/53#issue-3880824088

Simply replaces the `G1 Z0` move on #1823 with `G1 Z5`, to prevent bed collision. 