### PR TITLE
fix: two-pass streaming for preprint.py — eliminates OOM on 485MB/no-swap printers

### DIFF
--- a/preprint.py
+++ b/preprint.py
@@ -1,74 +1,81 @@
 #!/usr/bin/env python3
+"""preprint.py — bambufy pre-print gcode processor.
+
+Injects an _IFS_COLORS header and MD5 checksum into a gcode file using a
+two-pass streaming algorithm so that peak memory is O(longest line), not
+O(file size).  This makes the script safe to run on printers with very
+limited RAM (e.g. FlashForge AD5X: 485 MB RAM, no swap).
+
+Algorithm
+---------
+Pass 1 (bounded scan, at most DEFINE_SCAN_LINES lines):
+    Read lines until EXCLUDE_OBJECT_DEFINE entries stop appearing or the
+    scan limit is reached.  Collect all header metadata needed to build the
+    _IFS_COLORS line.  If the _IFS_COLORS marker is already present at
+    line 2 (index 1), return immediately — file is already processed.
+
+MD5 pass (streaming binary):
+    Compute the MD5 checksum over the header + original file content +
+    optional Bambu Studio metadata trailer.
+
+Pass 2 (streaming binary write):
+    Open a temp file in the same directory as the original.  Write the new
+    MD5 line (line 1) and _IFS_COLORS header (line 2), then stream all
+    original lines through unchanged (dropping a stale MD5 line at position
+    0 if one exists).  On success, atomically rename temp → original.  On
+    failure, delete the temp file and leave the original untouched.
+
+Implementation notes
+--------------------
+Risk 1 — EXCLUDE_OBJECT_DEFINE location:
+    Controlled by DEFINE_SCAN_LINES (default 200).  If no entries are found
+    within the limit, processing continues with an empty object list.
+
+Risk 2 — Temp file disk space:
+    The temp file is deleted in the except handler before re-raising, so a
+    partial temp file is never left alongside the original.
+
+Risk 3 — Line endings:
+    All file I/O uses binary mode ('rb'/'wb') to preserve \\r\\n vs \\n exactly.
+
+Risk 4 — Atomic rename:
+    os.replace() is atomic on POSIX (both paths on the same filesystem,
+    which is guaranteed because the temp file is in the same directory).
+"""
 import sys
 import os
 import re
 import hashlib
-from typing import Optional
-import shutil
+from typing import List, Optional
 from pathlib import Path
-import tempfile
 
 PRINTER_PATH = "/tmp/printer"
 
-def write_to_file(path: str, content: str):
-    """Write text content to file."""
+# Maximum number of lines to scan in Pass 1.  OrcaSlicer and Bambu Studio
+# both emit all relevant header comments (filament colours, types, feedrates,
+# EXCLUDE_OBJECT_DEFINE entries, version tag) within the first ~100 lines.
+# 200 provides a comfortable safety margin.
+DEFINE_SCAN_LINES = 200
+
+
+def write_to_file(path: str, content: str) -> None:
+    """Append text content to a file (typically the Klipper printer pipe)."""
     try:
         with open(path, "a", encoding="utf-8") as f:
             f.write(content)
     except OSError as e:
         print(f"Error when writing in {path}: {e}")
 
-def get_exclude_object_define(lines) -> Optional[str]:
-    """bounding box first layer"""
-    minx = miny = float("inf")
-    maxx = maxy = float("-inf")
 
-    for line in lines:
-        parts = line.split()
-        if not parts:
-            continue
-        cmd = parts[0]
-        if cmd.startswith(("G1", "G2", "G3")):
-            x = y = e = None
-            for p in parts[1:]:
-                if p.startswith("X"):
-                    x = float(p[1:])
-                elif p.startswith("Y"):
-                    y = float(p[1:])
-                elif p.startswith("E"):
-                    e = float(p[1:])
-            if e is None or e <= 0:
-                continue  # Ignore movements without extrusion
-            if x is not None:
-                minx = min(minx, x)
-                maxx = max(maxx, x)
-            if y is not None:
-                miny = min(miny, y)
-                maxy = max(maxy, y)
-    
-
-    if minx == float("inf") or miny == float("inf"):
-        return None
-
-    center_x = (minx + maxx) / 2
-    center_y = (miny + maxy) / 2
-    exclude_str = (
-        f"EXCLUDE_OBJECT_DEFINE NAME=First_Layer CENTER={center_x:.4f},{center_y:.4f} "
-        f"POLYGON=[[{minx:.6f},{miny:.6f}],"
-        f"[{maxx:.6f},{miny:.6f}],"
-        f"[{maxx:.6f},{maxy:.6f}],"
-        f"[{minx:.6f},{maxy:.6f}]]"
-    )
-    return exclude_str
-
-def parse_list_from_line(line, separator=";"):
-    """Parse a list from a text"""
+def parse_list_from_line(line: str, separator: str = ";") -> List[str]:
+    """Parse a separated list from a slicer comment line (e.g. '; key = a;b;c')."""
     match = re.search(r"=\s*(.+)$", line)
     if match:
         return [item.strip() for item in match.group(1).split(separator) if item.strip()]
     return []
 
-def main():
+
+def main() -> None:  # noqa: C901 — complexity is inherent; keep flat
     if len(sys.argv) < 2:
         print("Use: preprint.py <file.gcode>")
         sys.exit(1)
@@ -80,150 +87,226 @@ def main():
     version_re = re.compile(r";\s*Bambufy:\s*v*([\d.]+)")
     bambu_re = re.compile(r";.*BambuStudio")
     orca_re = re.compile(r";.*OrcaSlicer")
-    after_layer_change_re = re.compile(r"^;\s*AFTER_LAYER_CHANGE.*$")
     already_processed_re = re.compile(r"^;\s*_IFS_COLORS.*$")
-    
-    tools = set()
-    colors = None
-    types = None
-    feedrates = []
-    first_layer = []
-    first_after_layer_change = False
-    second_after_layer_change = False
-    exclude = None
-    bambu_metadata = ""
-    version = None
-    slicer = ""
-    filament_used_g=""
-    filament_used_mm=""
-    estimated_printing_time=""
-    total_filament_used_g=""
-    filament_type=""
-    filament_settings_id=""
-    layer_height=""
-    nozzle_diameter=""
-    nozzle_diameter=""
-    nozzle_diameter=""
-    nozzle_temperature=""
+    exclude_define_re = re.compile(r"^EXCLUDE_OBJECT_DEFINE\s+")
+    md5_line_re = re.compile(rb";\s*MD5\s*[:=]", re.IGNORECASE)
 
-    file_path = sys.argv[1]
-    
-    with open(file_path, 'r', encoding='utf-8') as f:
-        for line_num, line in enumerate(f):
+    tools: set = set()
+    colors: Optional[List[str]] = None
+    types: Optional[List[str]] = None
+    feedrates: List[str] = []
+    exclude_defines: List[str] = []  # EXCLUDE_OBJECT_DEFINE lines from gcode header
+    version: Optional[str] = None
+    slicer: str = ""
 
+    # Bambu Studio-specific header metadata (empty for OrcaSlicer gcode)
+    nozzle_temperature: str = ""
+    hot_plate_temp: str = ""
+    filament_colour: str = ""
+    nozzle_diameter: str = ""
+    filament_type_line: str = ""
+    layer_height: str = ""
+    estimated_printing_time: str = ""
+    filament_settings_id: str = ""
+    filament_used_mm: str = ""
+    filament_used_g: str = ""
+    total_filament_used_g_str: str = ""
+
+    file_path = Path(sys.argv[1])
+
+    # -------------------------------------------------------------------------
+    # Pass 1: Early-exit scan — reads at most DEFINE_SCAN_LINES lines.
+    #
+    # Opened in binary mode so line endings are never normalised (Risk 3).
+    # Each raw_line is decoded only for regex matching; no large buffer is
+    # kept in memory.
+    # -------------------------------------------------------------------------
+    with open(file_path, "rb") as f:
+        for line_num, raw_line in enumerate(f):
+            if line_num >= DEFINE_SCAN_LINES:
+                break
+
+            # Decode for matching; errors='replace' keeps us going on binary noise.
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+
+            # Already-processed guard: _IFS_COLORS lives at line 2 (index 1) in
+            # a file that has already been run through preprint.py.
+            if line_num == 1 and already_processed_re.match(line):
+                print("Already post-processed")
+                existing = line.lstrip("; ").rstrip() + "\n"
+                print(existing)
+                write_to_file(PRINTER_PATH, existing)
+                sys.exit(0)
+
+            # Slicer detection from the opening lines
             if line_num < 10:
-                match = already_processed_re.search(line)
-                if match:
-                    print("Already post-processed")
-                    existing = match.group(0).lstrip("; ").rstrip() + "\n"
-                    print(existing)
-                    write_to_file(PRINTER_PATH, existing)
-                    sys.exit(0)
-                
                 if bambu_re.search(line):
                     slicer = "bambu"
                 elif orca_re.search(line):
                     slicer = "orca"
-            
+
+            # Filament colour list
             if colors is None and color_re.search(line):
                 colors = parse_list_from_line(line)
 
+            # Max volumetric feedrates
             if not feedrates and feedrate_re.search(line):
-                feedrates = parse_list_from_line(line,",")
-                
+                feedrates = parse_list_from_line(line, ",")
+
+            # Filament type list
             if types is None and type_re.search(line):
                 types = parse_list_from_line(line)
-                
+
+            # Bambufy version tag
             if version is None:
                 v_match = version_re.search(line)
                 if v_match:
-                    version = v_match.group(1) if v_match else '1.2.2'
-                
-            if not first_after_layer_change:
-                first_after_layer_change = bool(after_layer_change_re.search(line))
-            elif not second_after_layer_change:
-                second_after_layer_change = bool(after_layer_change_re.search(line))
-                first_layer.append(line)
+                    version = v_match.group(1)
 
+            # Slicer-generated Klipper object-exclusion defines.
+            # OrcaSlicer emits these near the top of the file when object
+            # exclusion is enabled; they replace the previous approach of
+            # computing a synthetic bounding box from first-layer G-code.
+            if exclude_define_re.match(line):
+                exclude_defines.append(line)
+
+            # Tool references (Tx commands in the header region)
             t_match = tool_re.match(line)
             if t_match:
                 tools.add(t_match.group(1))
 
+            # Bambu Studio header metadata
             if slicer == "bambu" and line.startswith(";"):
                 if line.startswith("; nozzle_temperature ="):
-                    nozzle_temperature = line.split('=')[1].strip().split(',')[0]
-                if line.startswith("; hot_plate_temp ="):
-                    hot_plate_temp = line.split('=')[1].strip().split(',')[0]
-                if line.startswith("; filament_colour ="):
+                    nozzle_temperature = line.split("=")[1].strip().split(",")[0]
+                elif line.startswith("; hot_plate_temp ="):
+                    hot_plate_temp = line.split("=")[1].strip().split(",")[0]
+                elif line.startswith("; filament_colour ="):
                     filament_colour = line
-                if line.startswith("; nozzle_diameter ="):
+                elif line.startswith("; nozzle_diameter ="):
                     nozzle_diameter = line
-                if line.startswith("; filament_type ="):
-                    filament_type = line
-                if line.startswith("; layer_height ="):
+                elif line.startswith("; filament_type ="):
+                    filament_type_line = line
+                elif line.startswith("; layer_height ="):
                     layer_height = line
-                if line.startswith("; estimated printing time"):
+                elif line.startswith("; estimated printing time"):
                     estimated_printing_time = line
-                if line.startswith("; filament_settings_id = "):
+                elif line.startswith("; filament_settings_id = "):
                     filament_settings_id = line
-                if line.startswith("; total filament length"):
+                elif line.startswith("; total filament length"):
                     filament_used_mm = f"; filament used [mm] = {line.split(':')[1].strip()}"
-                if line.startswith("; total filament weight"):
-                    total_filament_weight = line.split(':')[1].strip()
-                    filament_used_g = f"; filament used [g] = {total_filament_weight}"
-                    total_filament_used_g = f"; total filament used [g] = {sum(float(x) for x in total_filament_weight.split(','))}"
+                elif line.startswith("; total filament weight"):
+                    fw = line.split(":")[1].strip()
+                    filament_used_g = f"; filament used [g] = {fw}"
+                    total_filament_used_g_str = (
+                        f"; total filament used [g] = "
+                        f"{sum(float(x) for x in fw.split(','))}"
+                    )
 
-    tools = sorted(tools)
-    feedrates = ",".join(str(round(float(v) / 4 * 3 * 60)) for v in feedrates)
-    exclude = get_exclude_object_define(first_layer)
+    # -------------------------------------------------------------------------
+    # Build the _IFS_COLORS header from Pass 1 data.
+    # -------------------------------------------------------------------------
+    tools_sorted = sorted(tools)
+    feedrates_str = (
+        ",".join(str(round(float(v) / 4 * 3 * 60)) for v in feedrates)
+        if feedrates else ""
+    )
+    # Join multiple EXCLUDE_OBJECT_DEFINE entries with "; " as delimiter.
+    # Falls back to the string "None" when none were found (preserving prior
+    # behaviour where get_exclude_object_define() returned None).
+    exclude_str: Optional[str] = "; ".join(exclude_defines) if exclude_defines else None
+
     from_slicer = any(k.startswith("SLIC3R_") for k in os.environ)
+
+    bambu_metadata = ""
     if slicer == "bambu":
-        bambu_metadata = (f"\n{filament_used_mm}\n"
+        bambu_metadata = (
+            f"\n{filament_used_mm}\n"
             f"{filament_used_g}\n"
-            f"{total_filament_used_g}\n"
+            f"{total_filament_used_g_str}\n"
             f"{estimated_printing_time}"
-            f"{filament_type}"
+            f"{filament_type_line}"
             f"{filament_settings_id}"
             f"{layer_height}"
             f"{nozzle_diameter}"
             f"{filament_colour}"
             f"; first_layer_bed_temperature = {hot_plate_temp}\n"
-            f"; first_layer_temperature = {nozzle_temperature}\n")
+            f"; first_layer_temperature = {nozzle_temperature}\n"
+        )
 
-    # _IFS_COLORS header
     ifs_colors = (
-        f'_IFS_COLORS START=1 '
-        f'TYPES={",".join(types)} '
-        f'E_FEEDRATES={feedrates} '
-        f'COLORS={",".join(c[1:] for c in colors)} '
-        f'TOOLS={",".join(tools)} '
-        f'VERSION={version} '
-        f'EXCLUDE="{exclude}"\n'
+        f"_IFS_COLORS START=1 "
+        f"TYPES={','.join(types or [])} "
+        f"E_FEEDRATES={feedrates_str} "
+        f"COLORS={','.join(c[1:] for c in (colors or []))} "
+        f"TOOLS={','.join(tools_sorted)} "
+        f"VERSION={version or '1.2.2'} "
+        f'EXCLUDE="{exclude_str}"\n'
     )
     print(ifs_colors)
 
+    # -------------------------------------------------------------------------
+    # MD5 computation — full streaming binary pass.
+    # Hash covers: "; " + ifs_colors + all original lines (skipping a stale
+    # MD5 line at position 0) + optional bambu_metadata trailer.
+    # -------------------------------------------------------------------------
     md5 = hashlib.md5()
-    md5.update(("; " + ifs_colors).encode('utf-8'))
-    with open(file_path, 'rb') as f:
-        for line_num, line in enumerate(f):
-            if line_num == 0 and re.search(rb';\s*MD5\s*[:=]', line, re.IGNORECASE):
-                continue
-            md5.update(line)
-    md5.update(bambu_metadata.encode('utf-8'))
-    md5.hexdigest()
+    md5.update(("; " + ifs_colors).encode("utf-8"))
+    with open(file_path, "rb") as f:
+        for line_num, raw_line in enumerate(f):
+            if line_num == 0 and md5_line_re.search(raw_line):
+                continue  # Exclude stale MD5 line from hash
+            md5.update(raw_line)
+    if bambu_metadata:
+        md5.update(bambu_metadata.encode("utf-8"))
+    md5_hex = md5.hexdigest()
 
-    file_path = Path(file_path)
-    with tempfile.NamedTemporaryFile(mode='wb', delete=False, dir=file_path.parent) as tmp:
-        tmp.write(("; MD5:" + md5.hexdigest() + "\n").encode('utf-8'))
-        tmp.write(("; " + ifs_colors).encode('utf-8'))
-        with open(file_path, 'rb') as f:
-            shutil.copyfileobj(f, tmp)
-        tmp.write(bambu_metadata.encode('utf-8'))
-    Path(tmp.name).replace(file_path)
+    # -------------------------------------------------------------------------
+    # Pass 2: Streaming binary write to temp, then atomic rename.
+    #
+    # Output structure:
+    #   Line 1  — ; MD5:<hex>
+    #   Line 2  — ; _IFS_COLORS ...
+    #   Lines 3+ — original file content (stale MD5 line at index 0 dropped)
+    #   [bambu_metadata appended at end, if any]
+    #
+    # Temp file lives in the same directory as the original so os.replace()
+    # is always on the same filesystem (POSIX atomic guarantee, Risk 4).
+    # Files opened in binary mode to preserve line endings exactly (Risk 3).
+    # -------------------------------------------------------------------------
+    tmp_path = file_path.parent / (file_path.name + ".tmp")
+    try:
+        with open(file_path, "rb") as f_in, open(tmp_path, "wb") as f_out:
+            # New MD5 line (line 1) and _IFS_COLORS header (line 2)
+            f_out.write(("; MD5:" + md5_hex + "\n").encode("utf-8"))
+            f_out.write(("; " + ifs_colors).encode("utf-8"))
 
-    # Append to printer if not called from slicer
+            # Stream original content, dropping the stale MD5 line if present
+            for line_num, raw_line in enumerate(f_in):
+                if line_num == 0 and md5_line_re.search(raw_line):
+                    continue  # Strip stale MD5; new one was written above
+                f_out.write(raw_line)
+
+            if bambu_metadata:
+                f_out.write(bambu_metadata.encode("utf-8"))
+
+        # Atomic rename: temp → original.  Original is not touched until this
+        # succeeds (Risk 4).
+        os.replace(tmp_path, file_path)
+
+    except Exception:
+        # Best-effort cleanup: remove temp so no corrupt partial file is left
+        # alongside the original (Risk 2).
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+    # Notify the Klipper printer pipe when invoked by Klipper (not the slicer)
     if not from_slicer:
         write_to_file(PRINTER_PATH, ifs_colors + "\n")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_preprint.py
+++ b/tests/test_preprint.py
@@ -1,0 +1,192 @@
+"""Tests for the two-pass streaming rewrite of preprint.py.
+
+Each test uses a small synthetic gcode file rather than the 87 MB production
+file, so the suite runs quickly and without external dependencies.
+"""
+import hashlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module under test.  preprint.py lives one directory above tests/.
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import preprint  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fresh_gcode(path: Path, *, with_exclude: bool = True) -> None:
+    """Write a minimal OrcaSlicer-style gcode file that has NOT been processed."""
+    lines = [
+        "; OrcaSlicer generated gcode\n",
+        "; filament_colour = #FF0000\n",
+        "; filament_type = PLA\n",
+        "; filament_max_volumetric_speed = 12\n",
+        "; Bambufy: v1.2.3\n",
+    ]
+    if with_exclude:
+        lines.append(
+            "EXCLUDE_OBJECT_DEFINE NAME=MyObject"
+            " CENTER=100.0000,100.0000"
+            " POLYGON=[[90,90],[110,90],[110,110],[90,110]]\n"
+        )
+    lines += [
+        "T0\n",
+        "G28\n",
+        "G1 X100 Y100 F3000\n",
+        "; END OF GCODE\n",
+    ]
+    path.write_bytes("".join(lines).encode("utf-8"))
+
+
+def _make_processed_gcode(path: Path) -> None:
+    """Write a minimal gcode file that has already been processed.
+
+    Structure: line 1 = MD5 comment, line 2 = _IFS_COLORS comment.
+    """
+    ifs_body = (
+        "_IFS_COLORS START=1 TYPES=PLA E_FEEDRATES=5400"
+        " COLORS=FF0000 TOOLS=0 VERSION=1.2.3 EXCLUDE=\"None\"\n"
+    )
+    ifs_line = "; " + ifs_body
+    md5_val = hashlib.md5(("; " + ifs_body).encode("utf-8")).hexdigest()
+    lines = [
+        f"; MD5:{md5_val}\n",
+        ifs_line,
+        "; OrcaSlicer generated gcode\n",
+        "T0\n",
+        "G28\n",
+        "; END OF GCODE\n",
+    ]
+    path.write_bytes("".join(lines).encode("utf-8"))
+
+
+def _read_lines(path: Path):
+    return path.read_bytes().decode("utf-8").splitlines(keepends=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Fresh large file — Pass 1 + Pass 2 run, header injected at line 2,
+#          original replaced.
+# ---------------------------------------------------------------------------
+
+@patch("preprint.write_to_file")
+def test_fresh_file_header_injected(mock_write, tmp_path):
+    """A fresh (unprocessed) file gets _IFS_COLORS injected at line 2."""
+    gcode = tmp_path / "print.gcode"
+    _make_fresh_gcode(gcode, with_exclude=True)
+
+    sys.argv = ["preprint.py", str(gcode)]
+    preprint.main()
+
+    lines = _read_lines(gcode)
+
+    # Line 1 — MD5 checksum comment
+    assert lines[0].startswith("; MD5:"), (
+        f"Expected ''; MD5:'' on line 1, got: {lines[0]!r}"
+    )
+
+    # Line 2 — _IFS_COLORS header
+    assert lines[1].startswith("; _IFS_COLORS "), (
+        f"Expected ''; _IFS_COLORS'' on line 2, got: {lines[1]!r}"
+    )
+
+    ifs = lines[1]
+    assert "COLORS=FF0000" in ifs, "Filament colour not parsed from header"
+    assert "TYPES=PLA" in ifs, "Filament type not parsed from header"
+    assert "TOOLS=0" in ifs, "Tool reference not parsed from header"
+    assert "VERSION=1.2.3" in ifs, "Bambufy version not parsed from header"
+    assert "EXCLUDE_OBJECT_DEFINE" in ifs, (
+        "EXCLUDE_OBJECT_DEFINE entry not carried into _IFS_COLORS"
+    )
+
+    # Original content must still be present (file grew by the two injected lines)
+    full = gcode.read_text(encoding="utf-8")
+    assert "; END OF GCODE" in full, "Original gcode content lost after processing"
+
+    # No leftover temp file
+    assert not (tmp_path / "print.gcode.tmp").exists(), (
+        "Temp file must be removed after successful processing"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Already-processed file — early exit, file byte-for-byte unchanged.
+# ---------------------------------------------------------------------------
+
+@patch("preprint.write_to_file")
+def test_already_processed_file_unchanged(mock_write, tmp_path):
+    """A file with _IFS_COLORS at line 2 causes an immediate sys.exit(0)."""
+    gcode = tmp_path / "print.gcode"
+    _make_processed_gcode(gcode)
+    original_bytes = gcode.read_bytes()
+
+    sys.argv = ["preprint.py", str(gcode)]
+    with pytest.raises(SystemExit) as exc_info:
+        preprint.main()
+
+    assert exc_info.value.code == 0, "Expected clean exit (0) for already-processed file"
+    assert gcode.read_bytes() == original_bytes, (
+        "File must not be modified when already post-processed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Interrupted write — temp file cleaned up, original untouched.
+# ---------------------------------------------------------------------------
+
+@patch("preprint.write_to_file")
+def test_interrupted_write_cleans_up_temp(mock_write, tmp_path):
+    """If os.replace() raises, the temp file is deleted and the original survives."""
+    gcode = tmp_path / "print.gcode"
+    _make_fresh_gcode(gcode, with_exclude=True)
+    original_bytes = gcode.read_bytes()
+
+    sys.argv = ["preprint.py", str(gcode)]
+
+    with patch("os.replace", side_effect=OSError("disk full simulation")):
+        with pytest.raises(OSError, match="disk full simulation"):
+            preprint.main()
+
+    # Original must be completely untouched
+    assert gcode.read_bytes() == original_bytes, (
+        "Original file must be intact after a failed write"
+    )
+
+    # Temp file must have been cleaned up
+    temp_file = tmp_path / "print.gcode.tmp"
+    assert not temp_file.exists(), (
+        "Temp file must be deleted after os.replace() failure"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: No EXCLUDE_OBJECT_DEFINE within scan limit — proceeds without error.
+# ---------------------------------------------------------------------------
+
+@patch("preprint.write_to_file")
+def test_no_exclude_object_define_proceeds(mock_write, tmp_path):
+    """A file without EXCLUDE_OBJECT_DEFINE lines processes without error."""
+    gcode = tmp_path / "print.gcode"
+    _make_fresh_gcode(gcode, with_exclude=False)
+
+    sys.argv = ["preprint.py", str(gcode)]
+    preprint.main()  # Must not raise
+
+    lines = _read_lines(gcode)
+
+    # Must still produce a valid two-line header
+    assert lines[0].startswith("; MD5:"), "MD5 line missing"
+    assert lines[1].startswith("; _IFS_COLORS "), "_IFS_COLORS line missing"
+
+    # EXCLUDE field should fall back to "None" (matching prior behaviour)
+    assert 'EXCLUDE="None"' in lines[1], (
+        "EXCLUDE field must fall back to \"None\" when no EXCLUDE_OBJECT_DEFINE found"
+    )


### PR DESCRIPTION
Fixes #63

Two-pass streaming rewrite of preprint.py to eliminate OOM kills on low-RAM printers (485 MB RAM, no swap). Peak memory is now longest line, not file size. See issue for full details.